### PR TITLE
feat: implement linkification utility and integrate wrapper

### DIFF
--- a/src/linkify.ts
+++ b/src/linkify.ts
@@ -1,0 +1,26 @@
+// Utility to linkify URLs in a DOM element
+export function linkifyTextInElement(element: HTMLElement, regex: RegExp) {
+  function processNode(node: Node): void{
+    if (node.nodeType === Node.TEXT_NODE) {
+      const text = node.textContent;
+
+      if (text && regex.test(text)) {
+        const temp = document.createElement('div');
+        temp.innerHTML = text.replace(
+          regex,
+          (match) =>
+            `<a href="${match}" target="_blank" rel="noopener noreferrer" style="color: #0066cc; text-decoration: underline;">${match}</a>`
+        );
+
+        const fragment = document.createDocumentFragment();
+        while (temp.firstChild) {
+          fragment.appendChild(temp.firstChild);
+        }
+        node.parentNode?.replaceChild(fragment, node);
+      }
+    } else if (node.nodeType === Node.ELEMENT_NODE && (node as Element).tagName !== 'A') {
+      Array.from(node.childNodes).forEach(child => processNode(child));
+    }
+  }
+  processNode(element);
+}


### PR DESCRIPTION
This pull request refactors the logic for converting URLs in code blocks into clickable links by extracting the linkification logic into a reusable utility function. It also simplifies and generalizes the React component wrapper responsible for applying this transformation, making the codebase cleaner and more maintainable.

**Refactoring and code reuse:**

* Extracted the linkification logic into a new utility function `linkifyTextInElement` in `src/linkify.ts`, making it reusable across the codebase.
* Replaced the inline linkification logic in the React component with the new utility function, and introduced a generic `createLinkifiedWrapper` function to wrap components for linkification.

**Plugin simplification and maintainability:**

* Updated the `ClickableLinksPlugin` in `src/plugin.tsx` to use the new wrapper function and utility, resulting in cleaner and more maintainable code.